### PR TITLE
Forcing dataType to xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,23 @@ It has been tested in various situations but if you encounter a problem or if yo
 Example of implementation in VizieR: http://vizier.u-strasbg.fr/vizier/welcome/
 where votable.js is used to load the metadata and to format it on the client side
 
+## Dependency
+
+votable.js has a dependency on jQuery.
+
+## Basic code usage
+
+    var p = new Parser();
+    
+    var success = function() {
+        p.SelectResource(0); // select 1st resource in document
+        p.SelectTable(0); // select 1st table in resource
+        var data = p.GetData();
+        console.log("Value of first field in first row: ", data.TR[0].TD[0]);
+    };
+    var error = function() {
+        alert('Something went wrong');
+    };
+    
+    p.setCallbackFunction(success, error);
+    p.load('http://vizier.u-strasbg.fr/viz-bin/votable/-A?-source=I/311/hip2&-c=M%2045&-out.max=999&-c.rd=5');

--- a/votable.js
+++ b/votable.js
@@ -118,7 +118,7 @@ function Parser() {
         var time = new Date().getTime()
         var asyncmode = false;
         if (thisParser.callbackfn != null) asyncmode = true;
-        $.ajaxSetup({async: asyncmode});
+        $.ajaxSetup({async: asyncmode, dataType: 'xml'});
 
         $.get(xmlDoc, function(DataXmlDoc) {
                 var i = 0, benchmark;


### PR DESCRIPTION
Current version of the parser does not work if the server outputs a mime-type not related to XML (eg text/plain)
Fixing the dataType to 'xml' fixes this issue
